### PR TITLE
fix: heights calculate error.

### DIFF
--- a/src/callout/manager.ts
+++ b/src/callout/manager.ts
@@ -141,7 +141,9 @@ export default class CalloutManager extends Component {
 
         let collapsed = callout.hasClass("is-collapsed");
 
-        this.getComputedHeights(content);
+        setTimeout(() => {
+            this.getComputedHeights(content);
+        }, 200);
 
         if (collapsed) {
             for (const prop of this.heights) {


### PR DESCRIPTION
fix error of the heights calculate of callout, in the old version, the calculated heights will be 0px and there will be problems with the folding animation.