### PR TITLE
Better Autocompletion for Callouts

### DIFF
--- a/src/assets/main.scss
+++ b/src/assets/main.scss
@@ -311,9 +311,20 @@
   }
 }
 
-.admonition-suggester-icon {
-  svg {
-    width: 1em;
+.suggestion-container > .suggestion > .suggestion-item.admonition-suggester-item {
+  color: rgb(var(--callout-color));
+
+  &.is-selected {
+    background-color: rgba(var(--callout-color), 0.1);
+  }
+
+  .admonition-suggester-icon {
+    &:not(:empty) {
+      padding-right: var(--size-4-1);
+    }
+
+    display: inline-block;
+    vertical-align: middle;
   }
 }
 


### PR DESCRIPTION
## Pull Request Description

WYSIWYG for the win! I added color and icons to the Callout-Suggester. Now, you don't need to remember icons or colors of your definitions (which I always forget).

## Changes Proposed

- [x] Icons in Autocompletion-Suggestions
- [x] Colors in Autocompletion-Suggestions
- [x] Fancy Alignment in Autocompletion-Suggestions

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

![image](https://github.com/javalent/admonitions/assets/65970327/0eeac8a5-bcbb-4147-b1f6-a9266a67975e)

## Additional Notes

When not using FontAwesome Icons, the suggestions stil show FA Icons, because thats how they're defined internally 🤷 

BEGIN_COMMIT_OVERRIDE
feat: Better Autocompletion for Callouts (thanks @heinrich26)
END_COMMIT_OVERRIDE