### PR TITLE
Fix Errors in suggest.ts

### DIFF
--- a/src/suggest/suggest.ts
+++ b/src/suggest/suggest.ts
@@ -51,7 +51,7 @@ abstract class AdmonitionOrCalloutSuggester extends EditorSuggest<
         const line = editor.getLine(cursor.line);
         const match = this.testAndReturnQuery(line, cursor);
         if (!match) return null;
-        const [_, query] = match;
+        const [_, prefix, query] = match;
 
         if (
             Object.keys(this.plugin.admonitions).find(
@@ -64,13 +64,12 @@ abstract class AdmonitionOrCalloutSuggester extends EditorSuggest<
         return {
             end: cursor,
             start: {
-                ch: match.index + this.offset,
+                ch: match.index + prefix.length,
                 line: cursor.line
             },
             query
         };
     }
-    abstract offset: number;
     abstract selectSuggestion(
         value: [string, Admonition],
         evt: MouseEvent | KeyboardEvent
@@ -82,34 +81,35 @@ abstract class AdmonitionOrCalloutSuggester extends EditorSuggest<
 }
 
 export class CalloutSuggest extends AdmonitionOrCalloutSuggester {
-    offset = 4;
     selectSuggestion(
         [text]: [text: string, item: Admonition],
         evt: MouseEvent | KeyboardEvent
     ): void {
         if (!this.context) return;
 
-        const line = this.context.editor
-            .getLine(this.context.end.line)
-            .slice(this.context.end.ch);
+        const { editor, query, start, end } = this.context;
+
+        const line = editor
+            .getLine(end.line)
+            .slice(end.ch);
         const [_, exists] = line.match(/^(\] ?)/) ?? [];
 
-        this.context.editor.replaceRange(
+        editor.replaceRange(
             `${text}] `,
-            this.context.start,
+            start,
             {
-                ...this.context.end,
+                ...end,
                 ch:
-                    this.context.start.ch +
-                    this.context.query.length +
+                    start.ch +
+                    query.length +
                     (exists?.length ?? 0)
             },
             "admonitions"
         );
 
-        this.context.editor.setCursor(
-            this.context.start.line,
-            this.context.start.ch + text.length + 2
+        editor.setCursor(
+            start.line,
+            start.ch + text.length + 2
         );
 
         this.close();
@@ -119,23 +119,31 @@ export class CalloutSuggest extends AdmonitionOrCalloutSuggester {
         cursor: EditorPosition
     ): RegExpMatchArray | null {
         if (/> ?\[!\w+\]/.test(line.slice(0, cursor.ch))) return null;
-        if (!/> ?\[!\w*/.test(line)) return null;
-        return line.match(/> ?\[!(\w*)\]?/);
+        
+        const match = line.match(/(> ?\[!)(\w*)\]?/);
+        if (!match) return null;
+        return match
     }
 }
 export class AdmonitionSuggest extends AdmonitionOrCalloutSuggester {
-    offset = 6;
     selectSuggestion(
         [text]: [text: string, item: Admonition],
         evt: MouseEvent | KeyboardEvent
     ): void {
         if (!this.context) return;
 
-        this.context.editor.replaceRange(
+        const { editor, start, end } = this.context;
+
+        editor.replaceRange(
             `${text}`,
-            this.context.start,
-            this.context.end,
+            start,
+            end,
             "admonitions"
+        );
+
+        editor.setCursor(
+            start.line,
+            start.ch + text.length
         );
 
         this.close();
@@ -145,6 +153,9 @@ export class AdmonitionSuggest extends AdmonitionOrCalloutSuggester {
         cursor: EditorPosition
     ): RegExpMatchArray | null {
         if (!/```ad-\w*/.test(line)) return null;
-        return line.match(/```ad-(\w*)/);
+        
+        const match = line.match(/(```ad-)(\w*)/);
+        if (!match) return null;
+        return match;
     }
 }

--- a/src/suggest/suggest.ts
+++ b/src/suggest/suggest.ts
@@ -64,6 +64,7 @@ abstract class AdmonitionOrCalloutSuggester extends EditorSuggest<
         return {
             end: cursor,
             start: {
+                // using 'prefix.length' instead of 'this.offset'
                 ch: match.index + prefix.length,
                 line: cursor.line
             },
@@ -87,6 +88,7 @@ export class CalloutSuggest extends AdmonitionOrCalloutSuggester {
     ): void {
         if (!this.context) return;
 
+        // Code Refactoring
         const { editor, query, start, end } = this.context;
 
         const line = editor
@@ -119,7 +121,8 @@ export class CalloutSuggest extends AdmonitionOrCalloutSuggester {
         cursor: EditorPosition
     ): RegExpMatchArray | null {
         if (/> ?\[!\w+\]/.test(line.slice(0, cursor.ch))) return null;
-        
+
+        // Modified the regex to capture 'prefix', 'query'
         const match = line.match(/(> ?\[!)(\w*)\]?/);
         if (!match) return null;
         return match
@@ -132,6 +135,7 @@ export class AdmonitionSuggest extends AdmonitionOrCalloutSuggester {
     ): void {
         if (!this.context) return;
 
+        // Code Refactoring
         const { editor, start, end } = this.context;
 
         editor.replaceRange(
@@ -141,6 +145,7 @@ export class AdmonitionSuggest extends AdmonitionOrCalloutSuggester {
             "admonitions"
         );
 
+        // Move the cursor to the end of the inserted text
         editor.setCursor(
             start.line,
             start.ch + text.length
@@ -153,7 +158,8 @@ export class AdmonitionSuggest extends AdmonitionOrCalloutSuggester {
         cursor: EditorPosition
     ): RegExpMatchArray | null {
         if (!/```ad-\w*/.test(line)) return null;
-        
+
+        // Modified the regex to capture 'prefix', 'query'
         const match = line.match(/(```ad-)(\w*)/);
         if (!match) return null;
         return match;


### PR DESCRIPTION
## Pull Request Description

This pull request fixes a bug that occurs when using ">[!" (without a space between ">" and "[") instead of "> [!".

## Changes Proposed

- In the testAndReturnQuery function, prefix and query groups were created during matching, enabling cursor movement without using an offset.
- So, we removed the unnecessary offset variable.
- In the AdmonitionSuggest class, when selecting a suggestion after "```ad-", modified it so that the cursor moves to the position after the text.
- Refactored the code, because "this.context" was used a lot.

## Related Issues

Fixes #339 ( Strange Behavior of Callout Type Autocompletion )

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)
1. Confirmed that ">[!n" works as expected when entered.
![image1](https://github.com/user-attachments/assets/529a1038-c4b2-4b25-98ce-d46f7d91f96b)
![image2](https://github.com/user-attachments/assets/04260f89-ab98-4985-b262-c7d1403bcd1c)

2. Confirmed that when entering ">[!", there is no line break and works as expected.
![image3](https://github.com/user-attachments/assets/0c8e1167-4569-42f3-bfbb-e4509dfbaa4b)
![image4](https://github.com/user-attachments/assets/3c1ca986-a8f0-4532-869b-360f11c270b6)

3. In the case of ">[! ", since \w follows in the regular expression, spaces were not considered.

4. Additionally, in the case of "```ad-", where the cursor was after the -, we adjusted it to move to the end of the text.
![image5](https://github.com/user-attachments/assets/bf68cf51-da2e-49d4-aecf-bf6aa41fb926)

(before)
![image6](https://github.com/user-attachments/assets/52a53c68-a7a6-4fe4-96c7-949cf20f8af6)

(after)
![image7](https://github.com/user-attachments/assets/6a262ea9-868a-478b-ba83-b0703e088cb3)



## Additional Notes

<!-- Any additional information or context you want to provide about the pull request -->

This is my second time creating a Pull requests, so it might not be perfect.
If I made any mistakes, I would appreciate it if you could let me know.
Thank you. 🍭