### PR TITLE
Reject uppercase in admonition type

### DIFF
--- a/src/util/validator.ts
+++ b/src/util/validator.ts
@@ -145,6 +145,13 @@ export class AdmonitionValidator {
                 failed: "type"
             };
         }
+        if (/[A-Z]/.test(type)) {
+            return {
+                success: false,
+                message: t("Admonition type cannot contain uppercase letters."),
+                failed: "type"
+            };
+        }
         if (type != oldType && type in plugin.data.userAdmonitions) {
             return {
                 success: false,


### PR DESCRIPTION
## Pull Request Description

Uppercase letters shouldn't be allowed in admonition type. Otherwise, it will cause failure when checking if the callout/admonition is a custom one; for example in the following:
https://github.com/javalent/admonitions/blob/f19389940b0148b677e106f503980cbb9f767f63/src/callout/manager.ts#L57

## Changes Proposed

- [x] Add an additional validation case that tests for uppercase.

## Related Issues

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [ ] I have tested the changes locally and they are working as expected.
- [ ] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [ ] I have checked for any potential security issues or vulnerabilities.

