### PR TITLE
feat: custom collapse behaviour

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -11,6 +11,7 @@ export interface Admonition {
     injectColor?: boolean;
     noTitle: boolean;
     copy?: boolean;
+    collapseType: "open" | "closed" | "none";
 }
 
 export interface NestedAdmonition {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -55,6 +55,9 @@ export default {
     "Show Copy Button": "Show Copy Button",
     "A copy button will be added to the admonition.":
         "A copy button will be added to the admonition.",
+    "Default Collapsible": "Default Collapsible",
+    "This will be the default collapsible state for this admonition type.":
+        "This will be the default collapsible state for this admonition type.",
     "Parse Titles as Markdown": "Parse Titles as Markdown",
     "Admonition Titles will be rendered as markdown.":
         "Admonition Titles will be rendered as markdown."

--- a/src/modal/index.ts
+++ b/src/modal/index.ts
@@ -5,6 +5,8 @@ import {
     SearchComponent,
     Setting,
     TextComponent,
+    DropdownComponent,
+    ValueComponent,
     renderMatches,
     setIcon
 } from "obsidian";
@@ -117,6 +119,10 @@ export class InsertAdmonitionModal extends Modal {
                             this.type.slice(1).toLowerCase();
                     }
                     titleInput.setValue(this.title);
+                    if(this.plugin.admonitions[this.type].collapseType){
+                        this.collapse = this.plugin.admonitions[this.type].collapseType;
+                        collapseDropdown.setValue(this.collapse);
+                    }
                 } else {
                     new Notice("No admonition type by that name exists.");
                     t.inputEl.value = "";
@@ -172,9 +178,12 @@ export class InsertAdmonitionModal extends Modal {
                     }
                 });
             });
+        
+        let collapseDropdown: DropdownComponent;
 
         const collapseSetting = new Setting(contentEl);
         collapseSetting.setName("Make Collapsible").addDropdown((d) => {
+            collapseDropdown = d;
             d.addOption("open", "Open");
             d.addOption("closed", "Closed");
             d.addOption("none", "None");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -163,7 +163,8 @@ export default class AdmonitionSetting extends PluginSettingTab {
                                     title: modal.title,
                                     injectColor: modal.injectColor,
                                     noTitle: modal.noTitle,
-                                    copy: modal.copy
+                                    copy: modal.copy,
+                                    collapseType: modal.collapseType
                                 };
                                 this.plugin.addAdmonition(admonition);
 
@@ -965,7 +966,8 @@ export default class AdmonitionSetting extends PluginSettingTab {
                                         title: modal.title,
                                         injectColor: modal.injectColor,
                                         noTitle: modal.noTitle,
-                                        copy: modal.copy
+                                        copy: modal.copy,
+                                        collapseType: modal.collapseType
                                     };
 
                                     if (
@@ -1037,6 +1039,7 @@ class SettingsModal extends Modal {
     admonitionPreviewParent: HTMLElement;
     admonitionPreview: HTMLElement;
     copy: boolean;
+    collapseType: "open" | "closed" | "none" = "none";
     originalType: string;
     editing = false;
     constructor(public plugin: ObsidianAdmonition, admonition?: Admonition) {
@@ -1051,6 +1054,7 @@ class SettingsModal extends Modal {
             this.injectColor = admonition.injectColor ?? this.injectColor;
             this.noTitle = admonition.noTitle ?? false;
             this.copy = admonition.copy ?? this.plugin.data.copyButton;
+            this.collapseType = admonition.collapseType ?? this.collapseType;
         }
     }
 
@@ -1177,6 +1181,25 @@ class SettingsModal extends Modal {
             .addToggle((t) => {
                 t.setValue(this.copy).onChange((v) => (this.copy = v));
             });
+        new Setting(settingDiv)
+            .setName(t("Default Collapsible"))
+            .setDesc(
+                createFragment((e) => {
+                    e.createSpan({
+                        text: t("This will be the default collapsible state for this admonition type.")
+                    });
+                })
+            )
+            .addDropdown((d) => {
+                d.addOption("open", "Open");
+                d.addOption("closed", "Closed");
+                d.addOption("none", "None");
+                d.setValue(this.collapseType);
+                d.onChange((v: "open" | "closed" | "none") => {
+                    this.collapseType = v;
+                });
+            });
+        
 
         const input = createEl("input", {
             attr: {


### PR DESCRIPTION
## Pull Request Description

When creating a custom Admotion type, the user can specify its default collapse behaviour

## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- Added "collapseType" inside the "Admotion" interface to store the preference
- Added the ablity to select the wanted collapse behaviour when creating a curstom admotion

## Related Issues

<!-- Mention any related issues or tasks that are addressed by this pull request -->

(Partially) Fixes #335 and a pet-hate of mine


## Checklist


- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [ ] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.


## Screenshots (if applicable)

...probably not necessary

## Additional Notes

Be aware: I'm basically a novice
